### PR TITLE
Make major and certificate requirement yaml files more human-readable

### DIFF
--- a/majors_and_certificates/README.md
+++ b/majors_and_certificates/README.md
@@ -2,11 +2,11 @@
 
 Each of the folders named `certificates`, `degrees`, and `majors`
 contains requirement files in either `JSON` or `YAML` format that are parsed
-by `scripts/verifier.py`.
+by [`scripts/verifier.py`](scripts/verifier.py).
 
 The parsed requirements are used to do automated requirements checking
 of the user's course schedule, and are then displayed to the user in
-the requirements tree panel on the right of the screen.
+the requirements tree panel.
 
 ## Requirement File Categories
 
@@ -19,33 +19,33 @@ respective departments.
 
 **Certificates** are also listed according to three-letter codes, but this
 is less standardized, and the codes are not officially used by the registrar.
-Certificates are currently not displayed to the user, but including them
-is a major future goal.
 
 The three-letter codes used for naming majors and certificates requirement
-files are listed in [`scripts/university_info.py`](https://github.com/TigerPathApp/tigerpath/blob/master/tigerpath/majors_and_certificates/scripts/university_info.py).
+files are listed in [`scripts/university_info.py`](scripts/university_info.py).
 
 ## Understanding requirement files
 
-Requirement files can be written in either `JSON` or `YAML` format.
-In the past, the verifier had accepted only `JSON` files, and the examples
-below are still in `JSON` format.
+Each requirements file is structured as a
+[tree](https://en.wikipedia.org/wiki/Tree_structure) with the full major at
+the root, and each requirement containing subrequirements as children.
+The leaves of the tree represent the simplest kind of requirement,
+which is usually a list of courses (encoded as a `course_list`).
+Intermediate nodes (which are encoded as a `req_list`, which is short for
+"requirement list") represent more complex requirement types, and express
+some kind of relationship among the subrequirements (for example, it may
+require that ALL subrequirements be completed, or it may require a choice of
+at least 1 of the subrequirements).
 
-More recently, the option to use `YAML` format was added.
-[`YAML`](https://en.wikipedia.org/wiki/YAML) is a superset of `JSON` but also
-includes extra features which allow for the possibility to write cleaner
-and more human-friendly requirement files.
-So while the verifier now reads the files using a `YAML` parser,
-either format is accepted.
-
-Because of this, all the older requirement files are written in `JSON` format
-(equivalently, compact `YAML`),
-but any newer requirement files can be written in either the `JSON` or
-`YAML` formats.
-
-Each requirements file is structured as a tree with the full major at the root. The leaves code for the simplest kind of requirement,
-which is usually a list of courses (encoded as a `course_list` or `dist_req`). Intermediate nodes (those
-containing a `req_list`) express the relationships among their children.
+Requirement files are written in `YAML`.
+[`YAML`](https://en.wikipedia.org/wiki/YAML) is a superset of `JSON` but which
+also includes extra features which allow for the possibility to write cleaner
+and more human-friendly requirement files. While `JSON` is also accepted
+by the `YAML` parser, the more succinct `YAML` form is preferred, since it
+is more easily read and maintained by a human.
+Note that it is easy to convert between the two using any `YAML` parser
+(for example, using an [online conversion tool](https://www.json2yaml.com/)).
+The expected format of the requirements files, as well as how they are
+interpreted, is explained below.
 
 ### Course Code Conventions
 
@@ -55,7 +55,7 @@ can count towards a requirement.
 
 Most course codes in these lists are just simply the registrar's course code
 for that course, such as `AAA 111`.
-This is optionally followed by a colon (`:`) and the name of the course.
+This is optionally followed by a colon (`:`) and the name or title of the course.
 Note that everything after the colon *is not parsed*, and is
 in fact just like a comment, used to aid a human reader in following along and
 checking the list of courses.
@@ -77,10 +77,6 @@ Here are the possible types of course codes:
 | AAA 101: Intro to Aardvarks                       | course listing with title <br>(title is ignored and only for human readability)   |
 
 ### Requirements Format Specifications
-
-Note: For the root node of the requirement tree, `min_needed` is always
-implicitly `"ALL"` and `max_counted` is irrelevant, so neither is
-explicitly present.
 
 A `*` in the comment describing a field signifies that it is **required**.
 
@@ -111,7 +107,7 @@ allowed_majors:
 # every source of information on the listed requirements should be linked to here
 # and the info in the links should back up every detail of the requirements file
 urls: #* links to requirements pages
-- https://ua.princeton.edu/academic-units/name-studies
+- "https://ua.princeton.edu/academic-units/name-studies"
 contacts: #* departmental office contacts for the department or certificate
 - type: Departmental Representative
   name: Dr. Professor
@@ -145,22 +141,28 @@ req_list: # the highest level **must** contain a req_list
     course_list: #* a course_list defines this requirement as an explicit or implicit list of courses
     - NST 100 # course lists contain the course codes
     - NST 2** # of courses satisfying the requirement
-    - NST 312C # and, optionally, a colon-sparated course name which is
-    - NST 96 # ignored by the parser (only for human reference)
+    - NST 312C # and, optionally, a colon-sparated course name which is ignored
+    - NST 96 # by the parser (only for human reference)
     - NST 482/ACR 382 # (see the course code conventions table above)
     - 'NST 487: The Study of Modern Names'
     # an optional list of courses excluded from counting for this requirement
     excluded_course_list: # the format is the same as for a course_list
     - NST 221 # this prevents NST 221 from counting, despite NST 2** listed above
-# any requirement that TigerPath cannot possibly verify,
+# any requirement that the app cannot possibly verify,
 # such as a Senior Thesis or internship, should contain a no_req
 # instead of a req_list or course_list. Here is an example:
 - name: Unverifiable Requirement
   max_counted: #*
   min_needed: #*
   explanation: All students must visit New York City three times. #*
-  no_req: #*
+  no_req: #* The value of the no_req field is ignored and may be empty/null
 ```
+
+Note: For the root node of the requirement tree, `min_needed` is always
+implicitly `"ALL"` and `max_counted` is irrelevant, so neither is
+explicitly present. In rare cases, `min_needed` may be provided explicitly at
+the root to override the default (for example if the top level of the tree
+happens to be an OR of different options).
 
 For legacy requirement files, many of which are still written in `JSON`,
 the format looks instead something like the following. Note that these are
@@ -170,7 +172,7 @@ both equivalent and equally valid `YAML` formats.
 { # Note: JSON does not normally allow comments, but this is JSON parsed as YAML
   "type": "Major", # for descriptions of these fields, see the YAML version above
   "name": "Name Studies",
-  "code": "NST", respectively.
+  "code": "NST",
   "degree": "AB",
   "description": "These are at most a couple sentences describing the Name Studies major/certificate.\nIt is not strictly required, but should be copied from an official source.",
   "allowed_majors": [
@@ -231,7 +233,7 @@ for degree types (AB: "Bachelor of Arts", and BSE: "Bachelor of Science in
 Engineering"), but will normally not be used in major or certificate
 requirement files, except perhaps in rare scenarios.
 
-These include the `num_courses`, which verifies that the user has taken at
+These include `num_courses`, which verifies that users have taken at
 least a certain prescribed number of courses by different checkpoints in
 their 4 years (used to track degree progress), and `dist_req`, which allows
 any courses that fall under the specified
@@ -241,55 +243,46 @@ to count.
 Here is an example of their usage:
 
 ```yaml
-{
-  "type": "Degree",
-  "name": "A.B.", # "A.B." or "B.S.E."
-  "code": "AB", # "AB" or "BSE"
-  "urls": [
-    "https://ua.princeton.edu/contents/program-study-degree-bachelor-arts",
-    ...
-  ],
-  "contacts": [
-    {
-      "type": "Dean",
-      "name": "Dr. Professor",
-      "email": "dprof@princeton.edu"
-    }
-  ],
-  "req_list": [
-    {
-      "name": "Degree Progress",
-      "max_counted": 1,
-      "min_needed": "ALL",
-      "explanation": "Explanation of degree progress requirements",
-      "req_list": [
-        {
-          "name": "Courses completed by 6th semester",
-          "max_counted": 1,
-          "explanation": null,
-          "completed_by_semester": 6,
-          "num_courses": 31 # number of course credits that must be completed
-          # note: min_needed is not present and is automatically set to num_courses
-        },
-        {
-          ...
-        }
-      ]
-    },
-    {
-      "name": "Epistemology and Cognition",
-      "max_counted": 1,
-      "min_needed": 1,
-      "explanation": "Explanation",
-      "dist_req": [
-        "EC" # the distribution requirement code: EC, EM, HA, etc.
-      ]
-    },
-    {
-        ... # another requirement
-    }
-  ]
-}
+---
+type: Degree
+name: A.B.  #* "A.B." or "B.S.E."
+code: AB  #* "AB" or "BSE"
+urls:
+- "https://ua.princeton.edu/contents/program-study-degree-bachelor-arts"
+contacts:
+- type: Dean
+  name: Dr. Professor
+  email: dprof@princeton.edu
+req_list:
+- name: Degree Progress
+  max_counted: 1
+  min_needed: ALL
+  explanation: Explanation of degree progress requirements
+  req_list:
+  - name: By 6th semester
+    max_counted: 1
+    explanation:
+    completed_by_semester: 6  #* semester by which these courses must be taken
+    num_courses: 25  #* number of course credits that must be completed
+    # note: min_needed is not present and is automatically set to num_courses
+  - name: Total courses
+    max_counted: 1
+    explanation:
+    completed_by_semester: 8
+    num_courses: 31
+- name: Epistemology and Cognition
+  max_counted: 1
+  min_needed: 1
+  explanation: Explanation
+  dist_req: # list of distribution area codes: EC, EM, HA, etc.
+  - EC  # usually, the list will contain only one code
+- name: Quantitative and Computational Reasoning
+  max_counted: 1
+  min_needed: 1
+  explanation: Explanation
+  dist_req:  # for codes that changed names, include both old and new codes
+  - QR
+  - QCR
 ```
 
 ### Class Year Differences
@@ -300,17 +293,18 @@ This is useful when the requirements differ for students in different class
 years.
 For example, the requirements for a certain major might change, but then
 only apply to the incoming class and later, or an exception might be made
-for a specific class year.
+for a specific class year (for instance some requirements were suspended or
+modified during the COVID19 pandemic).
 
 A `year_switch` is formatted almost like a `req_list`, in that its value is
 a list of subrequirements.
-Each subrequirement must have a `year_code` field, a string or integer which
-specifies which class year range that the subrequirement applies to
+Each subrequirement must have a `year_code` field, which is a string or integer
+which specifies which class year range that the subrequirement applies to
 (refer to the [table below](#year-code-values) for possible values).
 Style dictates that, for readability, the `year_code` field should always
 appear at the top of the subrequirement.
 
-The first requirement in the list whose `year_code` matches the student's
+The *first* requirement in the list whose `year_code` matches the student's
 class year is selected, at which point its explicitly listed fields override
 those of the parent requirement (the one that contains the `year_switch`),
 and the `year_switch` and `year_code` fields are dropped.
@@ -445,4 +439,74 @@ The possible values for the `year_code` field are as follows:
 | "<XXXX", "<=XXXX", ">XXXX", ">=XXXX", "==XXXX", "!=XXXX"   | less than, less than or equal to, etc. the year XXXX  |
 | "XXXX" (a str) or XXXX (an int)                            | same as ==XXXX                                        |
 | "XXXX-YYYY"                                                | inclusive range of years: >=XXXX and <=YYYY           |
-| "default", null, empty or missing                          | course listing                                        |
+| "default", null, empty or missing                          | default case, applied when no other case matches      |
+
+
+### Deduplicating course lists
+
+Course lists sometimes appear multiple times in the same requirements file,
+and maintaining the duplicated lists separately can become a source of
+headache. Fortunately, `YAML` provides a way to alias and reference previously
+defined course lists.
+
+For instance, in the following requirement the "Electives" subrequirement
+excludes all the courses from the `course_list` of the "Core" subrequirement.
+Any time the list of core courses is modified, it must be edited in both
+locations and they must be manually checked for consistency.
+
+```yaml
+req_list:
+- name: Core courses
+  max_counted: 1
+  min_needed: ALL
+  explanation: Take all the required core courses
+  course_list:
+  - NST 237
+  - NST 244
+  - NST 253
+  - NST 273
+- name: Electives
+  max_counted: 1
+  min_needed: 2
+  explanation: Two 200-level courses beyond the core courses
+  course_list:
+  - NST 2**
+  excluded_course_list:  # core courses do not count
+  - NST 237
+  - NST 244
+  - NST 253
+  - NST 273
+```
+
+Instead, the first course list may be assigned an alias, which is then
+referenced the second time. The following is identical to the requirement
+above, but the course list is deduplicated, which allows it to be maintained
+in a single location.
+
+```yaml
+req_list:
+- name: Core courses
+  max_counted: 1
+  min_needed: ALL
+  explanation: Take all the required core courses
+  course_list: &core_courses_list  # an alias is defined for the following list
+  - NST 237
+  - NST 244
+  - NST 253
+  - NST 273
+- name: Electives
+  max_counted: 1
+  min_needed: 2
+  explanation: Two 200-level courses beyond the core courses
+  course_list:
+  - NST 2**
+  excluded_course_list: *core_courses_list  # references the list defined above
+```
+
+Note that this feature of `YAML` may not be intuitive to human readers,
+so always include comments explaining the situation whenever using this
+feature. For example, when referencing a previously defined alias, add
+a comment specifying which course list this is referencing and where to
+find the original definition. Furthermore, always use a descriptive name
+for the alias (i.e. `"core_courses_list"` as opposed to something generic
+like `"id001"`).

--- a/majors_and_certificates/degrees/AB.yaml
+++ b/majors_and_certificates/degrees/AB.yaml
@@ -1,172 +1,338 @@
-{
-  "type": "Degree",
-  "name": "A.B.",
-  "code": "AB",
-  "description": "The A.B. program at Princeton is intended to stretch students' minds and challenge their imaginations--to teach them to think and reason and document and prove, to cast a critical eye on conventional wisdom, to make sense of evidence, to read a text with care and critical insight, to conceptualize and solve problems, and to express themselves clearly and convincingly on paper and in discussion. Working within the general curricular framework, each undergraduate pursuing the A.B. degree is encouraged to develop an academic program in response to personal aspirations and interests. Each student's program of study encompasses a combination of courses that satisfy general education and departmental requirements, and substantial independent work during the junior and senior years.",
-  "urls": [
-    "https://ua.princeton.edu/contents/program-study-degree-bachelor-arts",
-    "https://ua.princeton.edu/contents/general-education-requirements"
-  ],
-  "req_list": [
-    {
-      "name": "Degree Progress",
-      "max_counted": 1,
-      "min_needed": "ALL",
-      "explanation": "With the exception of students who receive one or two terms of advanced standing, all A.B. students must successfully complete a minimum of 31 courses and two years of departmental independent work in eight terms of study. An extra term or year of study is granted by the Faculty Committee on Examinations and Standing to a student making normal progress toward the degree only under extraordinary circumstances.\n\nThe normal course load for first-years, sophomores, and juniors is four courses each term, with the exception of one term in the first or sophomore year when a student typically will need to take five courses in order to meet the expectation that 17 courses will have been completed by the start of junior year.\n\nRegardless of the number of courses completed prior to entering senior year, all seniors must, with the exception of the two programs listed below, complete a minimum of six courses in senior year. This is most often accomplished by enrolling in three courses each term but students may take four courses in one term and two courses in the other. Students in the Program in Teacher Preparation who have taken an extra course in an earlier year or a student who is participating in the University Scholar Program may be permitted to reduce their course load by one course in the senior year.",
-      "completed_by_semester": 8,
-      "req_list": [
-        {
-          "name": "By first semester",
-          "max_counted": 1,
-          "explanation": null,
-          "completed_by_semester": 1,
-          "num_courses": 4
-        },
-        {
-          "name": "By second semester",
-          "max_counted": 1,
-          "explanation": null,
-          "completed_by_semester": 2,
-          "num_courses": 8
-        },
-        {
-          "name": "By fourth semester",
-          "max_counted": 1,
-          "explanation": null,
-          "completed_by_semester": 4,
-          "num_courses": 17
-        },
-        {
-          "name": "By sixth semester",
-          "max_counted": 1,
-          "explanation": null,
-          "completed_by_semester": 6,
-          "num_courses": 25
-        },
-        {
-          "name": "Total courses",
-          "max_counted": 1,
-          "explanation": null,
-          "completed_by_semester": 8,
-          "num_courses": 31
-        }
-      ]
-    },
-    {
-      "name": "Writing Seminar",
-      "max_counted": 1,
-      "min_needed": 1,
-      "explanation": "<i>One course, completed in the first year</i>\n\nAll Princeton undergraduates take a Writing Seminar in the Fall or Spring of their first year.\n\nThe Writing Seminars give Princeton first-year students an early opportunity to belong to a lively academic community in which members investigate a shared topic and discuss their writing together, with the aim of clarifying and deepening their thinking. The seminars are interdisciplinary in nature to emphasize transferable reading, writing and research skills. You’ll learn how to frame compelling questions, position your argument within a genuine academic debate, substantiate and organize claims, purposefully integrate a wide variety of sources and revise for greater cogency and clarity.\n\nMore information:\n<a href=\"https://writing.princeton.edu/undergraduates/writing-seminars/fall-seminars\" target=\"_blank\" rel=\"noopener\">https://writing.princeton.edu/undergraduates/writing-seminars/fall-seminars</a>\n\nEnrollment process:\n<a href=\"https://writing.princeton.edu/seminars/how-enroll\" target=\"_blank\" rel=\"noopener\">https://writing.princeton.edu/seminars/how-enroll</a>",
-      "pdfs_allowed": false,
-      "completed_by_semester": 2,
-      "course_list": [
-        "WRI 1**"
-      ]
-    },
-    {
-      "name": "Foreign Language",
-      "max_counted": 1,
-      "min_needed": 1,
-      "explanation": "<i>One to four terms to complete, depending on the language students study and the level at which they start</i>\n\nWhen you become proficient in a foreign language, you acquire more than a communication skill; you become literate in another culture and gain another perspective on the world. All candidates for the A.B. degree at Princeton must demonstrate proficiency in a foreign language before graduation. Many undergraduates satisfy the foreign language requirement by demonstrating proficiency when they enter the University. In order to fulfill the language requirement through coursework, we expect successful completion of courses normally numbered through 107/108. ",
-      "double_counting_allowed": false,
-      "course_list": [
-        "LANG 1027",
-        "LANG 107",
-        "LANG 108",
-        "LANG 2**",
-        "LANG 3**",
-        "LANG 4**",
-        "LANG 5**"
-      ]
-    },
-    {
-      "name": "Culture and Difference",
-      "max_counted": 1,
-      "min_needed": 1,
-      "explanation": "<i>One course</i>\n\nThe requirement in Culture and Difference (CD) begins with the premise that human beings experience the world through their respective cultures—the ideas, meanings, norms, and habituations – that are represented in the arts and literature, laws and institutions, and social practices of human societies whose histories and power relationships often differ from one another. Found across a wide range of disciplines, these courses use cultural analysis to trace the ways in which human beings construct meaning both within and across groups. Culture and Difference courses offer students a lens through which other forms of disciplinary inquiry are enhanced, critiqued, and clarified, often paying close attention to the experiences and perspectives of groups who have historically been excluded from dominant cultural narratives or structures of social power.\n\nThe requirement in Culture and Difference is the only requirement that may be satisfied either independently or concurrently with another distribution area.",
-      "double_counting_allowed": true,
-      "dist_req": "CD",
-      "year_switch": [
-        {
-          "year_code": "<=2023",
-          "max_counted": 0,
-          "min_needed": 0,
-          "explanation": "<i>New! Only required for the class of 2024 and later.</i>\n\nThe requirement in Culture and Difference (CD) begins with the premise that human beings experience the world through their respective cultures—the ideas, meanings, norms, and habituations – that are represented in the arts and literature, laws and institutions, and social practices of human societies whose histories and power relationships often differ from one another. Found across a wide range of disciplines, these courses use cultural analysis to trace the ways in which human beings construct meaning both within and across groups. Culture and Difference courses offer students a lens through which other forms of disciplinary inquiry are enhanced, critiqued, and clarified, often paying close attention to the experiences and perspectives of groups who have historically been excluded from dominant cultural narratives or structures of social power.\n\nThe requirement in Culture and Difference is the only requirement that may be satisfied either independently or concurrently with another distribution area.",
-        }
-      ]
-    },
-    {
-      "name": "Epistemology and Cognition",
-      "max_counted": 1,
-      "min_needed": 1,
-      "explanation": "<i>One course</i>\n\nCourses in Epistemology and Cognition (EC) address the nature and limits of human knowledge. The cognitive sciences and related fields study human reasoning as it is. Epistemology — the philosophical theory of knowledge — studies human reasoning as it ought to be. Both areas of inquiry focus simultaneously on the manifold sources of human knowledge and on the many ways in which human reasoning can be distorted or undermined. Courses in this group are offered in a number of departments, but share the common goal of encouraging students to reflect on the linguistic, psychological, and cultural structures that make knowledge possible. Individual departments may also offer courses in disciplinary “ways of knowing” that invite students to consider the epistemological assumptions and methodological principles that inform research in their fields.",
-      "dist_req": "EC"
-    },
-    {
-      "name": "Ethical Thought and Moral Values",
-      "max_counted": 1,
-      "min_needed": 1,
-      "explanation": "<i>One course</i>\n\nCourses in Ethical Thought and Moral Values (EM) equip students to understand the basis of their own moral reasoning and ethical issues as they arise in social life, while also cultivating the possibility of a common ethical language among people whose traditions and values differ.\n\nHuman beings often disagree about matters of right and wrong, and about how we ought to organize our lives together. The ethical and moral conclusions we reach, however, are not mere matters of opinion. Ethical decisions emerge from fundamental ideas about the nature and possibility of the “good,” our duties and obligations to one another, our aspirations for a virtuous and meaningful life, and the demands of justice. These ideas, often shaped by ancient traditions of religion and culture, guide the moral questions we ask and the conclusions we reach.",
-      "dist_req": "EM"
-    },
-    {
-      "name": "Historical Analysis",
-      "max_counted": 1,
-      "min_needed": 1,
-      "explanation": "<i>One course</i>\n\nHistorical Analysis (HA) invites students to enter imaginatively into languages, institutions, and worldviews of the past. It grounds us in the awareness that human life and culture are thousands of years old, and that the world we experience in the present is only a fraction of all that it ever was. Fundamental to historical analysis is the study of change over time: why and how did cities rise and fall, technologies develop, the social roles of men and women transform? Because we can never directly experience the past, historical analysis depends on the subjective selection and interpretation of texts, artifacts, and other evidence, and from the same evidence many different stories can often be told. Historical analysis requires students to make critical judgments about the conclusions we can draw from the traces of the past to which we have access.",
-      "dist_req": "HA"
-    },
-    {
-      "name": "Literature and the Arts",
-      "max_counted": 1,
-      "min_needed": 2,
-      "explanation": "<i>Two courses</i>\n\nIn courses in Literature and the Arts (LA), students may produce creative, imaginative works or practice interpreting them. For example, they may choreograph dances or read Shakespeare plays or create performance pieces that use imaginative and interpretive skills critically and physically. The skill of “close reading” is especially important in this area of inquiry: what can we learn from careful attention to the precise words, colors, or tones that an artist has chosen?\n\nHuman beings have always used imagination to create reflections and representations of ourselves and our world, from cave paintings to symphonies to video games. In making these artistic or imaginative representations, we express ideas about our own nature and investigate the nature of the world around us, often in ways that push at the boundaries of what can be said in ordinary language.",
-      "dist_req": "LA"
-    },
-    {
-      "name": "Social Analysis",
-      "max_counted": 1,
-      "min_needed": 2,
-      "explanation": "<i>Two courses</i>\n\nSocial Analysis (SA) involves the study of the structures, processes, and meanings human beings create through our interactions with one another, and the networks and institutions through which human behavior develops and evolves. The codes and narratives we share with others, often unspoken, produce our sense of “the normal” and structure our thought and behavior. These components of social life are accessible through both quantitative methods, which involve the statistical analysis of data, and qualitative methods, which rely on the interpretation of data gathered through observation and interaction. Social analysis enables us to make sense of the social structures and processes that shape individual lives, to understand the role of institutions—such as the family, government, schools, and labor markets—in society, and to define and respond to social problems, such as inequality and violence.",
-      "dist_req": "SA"
-    },
-    {
-      "name": "Quantitative and Computational Reasoning",
-      "max_counted": 1,
-      "min_needed": 1,
-      "explanation": "<i>One course</i>\n\nQuantitative and Computational Reasoning (QCR) engages students in the logic of mathematics and the manipulation of numerical and categorical information. Quantitative reasoning asks us to describe and predict things that can be measured or counted such as population, speed, or cost. Computational thinking informs the underlying structures of the codes and algorithms created in computer science. Quantitative and computational reasoning is used to some degree in almost every area of learning. A strong foundation in quantitative reasoning helps students think clearly and apply quantitative methods to a wide range of projects, and equips them to critically evaluate statistical claims.",
-      "dist_req": [
-        "QR",
-        "QCR"
-      ]
-    },
-    {
-      "name": "Science and Engineering",
-      "max_counted": 1,
-      "min_needed": 2,
-      "explanation": "<i>Two courses. At least one course must be a science and engineering course with laboratory (SEL).</i>\n\nScience and Engineering (SEL/SEN) encompass the study of the natural and constructed worlds, their impact on humanity, and the human impact on them. These disciplines teach principles, methods, and systematic thinking, how to innovate theories and methodologies, how to test hypotheses and prototypes by analyzing data while managing uncertainty, and how to enhance the built world through creativity and design. Fundamental to science and engineering are the methods and habits of mind in which models are developed, critiqued, and refined, thereby enriching and expanding our ways of understanding – and fascination with – the natural and constructed environments, and our own positions within them.\n\nAt least one course must be a science and engineering course with laboratory (SEL). Students may elect a second laboratory science course, or a nonlaboratory science course (SEN).",
-      "req_list": [
-        {
-          "name": "Science and Engineering with Lab",
-          "max_counted": null,
-          "min_needed": 1,
-          "explanation": "Science and Engineering with Lab (SEL)",
-          "dist_req": [
-            "STL",
-            "SEL"
-          ]
-        },
-        {
-          "name": "Science and Engineering without Lab",
-          "max_counted": 1,
-          "min_needed": null,
-          "explanation": "Science and Engineering without Lab (SEN)",
-          "dist_req": [
-            "STN",
-            "SEN"
-          ]
-        }
-      ]
-    }
-  ]
-}
+---
+type: Degree
+name: A.B.
+code: AB
+description: The A.B. program at Princeton is intended to stretch students' minds
+  and challenge their imaginations--to teach them to think and reason and document
+  and prove, to cast a critical eye on conventional wisdom, to make sense of evidence,
+  to read a text with care and critical insight, to conceptualize and solve problems,
+  and to express themselves clearly and convincingly on paper and in discussion. Working
+  within the general curricular framework, each undergraduate pursuing the A.B. degree
+  is encouraged to develop an academic program in response to personal aspirations
+  and interests. Each student's program of study encompasses a combination of courses
+  that satisfy general education and departmental requirements, and substantial independent
+  work during the junior and senior years.
+urls:
+- "https://ua.princeton.edu/contents/program-study-degree-bachelor-arts"
+- "https://ua.princeton.edu/contents/general-education-requirements"
+req_list:
+- name: Degree Progress
+  max_counted: 1
+  min_needed: ALL
+  explanation: >-
+    With the exception of students who receive one or two terms of advanced
+    standing, all A.B. students must successfully complete a minimum of 31
+    courses and two years of departmental independent work in eight terms of
+    study. An extra term or year of study is granted by the Faculty Committee
+    on Examinations and Standing to a student making normal progress toward the
+    degree only under extraordinary circumstances.
+
+
+    The normal course load for first-years, sophomores, and juniors is four
+    courses each term, with the exception of one term in the first or sophomore
+    year when a student typically will need to take five courses in order to
+    meet the expectation that 17 courses will have been completed by the start
+    of junior year.
+
+
+    Regardless of the number of courses completed prior to entering senior
+    year, all seniors must, with the exception of the two programs listed
+    below, complete a minimum of six courses in senior year. This is most
+    often accomplished by enrolling in three courses each term but students
+    may take four courses in one term and two courses in the other. Students
+    in the Program in Teacher Preparation who have taken an extra course in an
+    earlier year or a student who is participating in the University Scholar
+    Program may be permitted to reduce their course load by one course in the
+    senior year.
+  completed_by_semester: 8
+  req_list:
+  - name: By first semester
+    max_counted: 1
+    explanation:
+    completed_by_semester: 1
+    num_courses: 4
+  - name: By second semester
+    max_counted: 1
+    explanation:
+    completed_by_semester: 2
+    num_courses: 8
+  - name: By fourth semester
+    max_counted: 1
+    explanation:
+    completed_by_semester: 4
+    num_courses: 17
+  - name: By sixth semester
+    max_counted: 1
+    explanation:
+    completed_by_semester: 6
+    num_courses: 25
+  - name: Total courses
+    max_counted: 1
+    explanation:
+    completed_by_semester: 8
+    num_courses: 31
+- name: Writing Seminar
+  max_counted: 1
+  min_needed: 1
+  explanation: >-
+    <i>One course, completed in the first year</i>
+
+
+    All Princeton undergraduates take a Writing Seminar in the Fall or Spring
+    of their first year.
+
+
+    The Writing Seminars give Princeton first-year students an early
+    opportunity to belong to a lively academic community in which members
+    investigate a shared topic and discuss their writing together, with the
+    aim of clarifying and deepening their thinking. The seminars are
+    interdisciplinary in nature to emphasize transferable reading, writing
+    and research skills. You’ll learn how to frame compelling questions,
+    position your argument within a genuine academic debate, substantiate
+    and organize claims, purposefully integrate a wide variety of sources
+    and revise for greater cogency and clarity.
+
+
+    More information:
+
+    <a href="https://writing.princeton.edu/undergraduates/writing-seminars/fall-seminars"
+    target="_blank" rel="noopener">https://writing.princeton.edu/undergraduates/writing-seminars/fall-seminars</a>
+
+
+    Enrollment process:
+
+    <a href="https://writing.princeton.edu/seminars/how-enroll"
+    target="_blank" rel="noopener">https://writing.princeton.edu/seminars/how-enroll</a>
+  pdfs_allowed: false
+  completed_by_semester: 2
+  course_list:
+  - WRI 1**
+- name: Foreign Language
+  max_counted: 1
+  min_needed: 1
+  explanation: "<i>One to four terms to complete, depending on the language students
+    study and the level at which they start</i>\n\nWhen you become proficient in a
+    foreign language, you acquire more than a communication skill; you become literate
+    in another culture and gain another perspective on the world. All candidates for
+    the A.B. degree at Princeton must demonstrate proficiency in a foreign language
+    before graduation. Many undergraduates satisfy the foreign language requirement
+    by demonstrating proficiency when they enter the University. In order to fulfill
+    the language requirement through coursework, we expect successful completion of
+    courses normally numbered through 107/108. "
+  double_counting_allowed: false
+  course_list:
+  - LANG 1027
+  - LANG 107
+  - LANG 108
+  - LANG 2**
+  - LANG 3**
+  - LANG 4**
+  - LANG 5**
+- name: Culture and Difference
+  max_counted: 1
+  min_needed: 1
+  explanation: |-
+    <i>One course</i>
+
+    The requirement in Culture and Difference (CD) begins with the premise
+    that human beings experience the world through their respective cultures
+    — the ideas, meanings, norms, and habituations – that are represented in
+    the arts and literature, laws and institutions, and social practices of
+    human societies whose histories and power relationships often differ from
+    one another. Found across a wide range of disciplines, these courses use
+    cultural analysis to trace the ways in which human beings construct
+    meaning both within and across groups. Culture and Difference courses
+    offer students a lens through which other forms of disciplinary
+    inquiry are enhanced, critiqued, and clarified, often paying close
+    attention to the experiences and perspectives of groups who have
+    historically been excluded from dominant cultural narratives or
+    structures of social power.
+
+    The requirement in Culture and Difference is the only requirement
+    that may be satisfied either independently or concurrently with
+    another distribution area.
+  double_counting_allowed: true
+  dist_req: CD
+  year_switch:
+  - year_code: "<=2023"
+    max_counted: 0
+    min_needed: 0
+    explanation: |-
+      <i>New! Only required for the class of 2024 and later.</i>
+
+      The requirement in Culture and Difference (CD) begins with the
+      premise that human beings experience the world through their
+      respective cultures—the ideas, meanings, norms, and habituations –
+      that are represented in the arts and literature, laws and institutions,
+      and social practices of human societies whose histories and power
+      relationships often differ from one another. Found across a wide range
+      of disciplines, these courses use cultural analysis to trace the ways
+      in which human beings construct meaning both within and across groups.
+      Culture and Difference courses offer students a lens through which
+      other forms of disciplinary inquiry are enhanced, critiqued, and
+      clarified, often paying close attention to the experiences and
+      perspectives of groups who have historically been excluded from
+      dominant cultural narratives or structures of social power.
+
+      The requirement in Culture and Difference is the only requirement
+      that may be satisfied either independently or concurrently with another
+      distribution area.
+- name: Epistemology and Cognition
+  max_counted: 1
+  min_needed: 1
+  explanation: |-
+    <i>One course</i>
+
+    Courses in Epistemology and Cognition (EC) address the nature and
+    limits of human knowledge. The cognitive sciences and related fields
+    study human reasoning as it is. Epistemology — the philosophical theory
+    of knowledge — studies human reasoning as it ought to be. Both areas of
+    inquiry focus simultaneously on the manifold sources of human knowledge
+    and on the many ways in which human reasoning can be distorted or
+    undermined. Courses in this group are offered in a number of departments,
+    but share the common goal of encouraging students to reflect on the
+    linguistic, psychological, and cultural structures that make knowledge
+    possible. Individual departments may also offer courses in disciplinary
+    “ways of knowing” that invite students to consider the epistemological
+    assumptions and methodological principles that inform research in
+    their fields.
+  dist_req: EC
+- name: Ethical Thought and Moral Values
+  max_counted: 1
+  min_needed: 1
+  explanation: |-
+    <i>One course</i>
+
+    Courses in Ethical Thought and Moral Values (EM) equip students to
+    understand the basis of their own moral reasoning and ethical issues
+    as they arise in social life, while also cultivating the possibility
+    of a common ethical language among people whose traditions and values
+    differ.
+
+    Human beings often disagree about matters of right and wrong, and about
+    how we ought to organize our lives together. The ethical and moral
+    conclusions we reach, however, are not mere matters of opinion.
+    Ethical decisions emerge from fundamental ideas about the nature and
+    possibility of the “good,” our duties and obligations to one another,
+    our aspirations for a virtuous and meaningful life, and the demands of
+    justice. These ideas, often shaped by ancient traditions of religion
+    and culture, guide the moral questions we ask and the conclusions we reach.
+  dist_req: EM
+- name: Historical Analysis
+  max_counted: 1
+  min_needed: 1
+  explanation: |-
+    <i>One course</i>
+
+    Historical Analysis (HA) invites students to enter imaginatively into
+    languages, institutions, and worldviews of the past. It grounds us in
+    the awareness that human life and culture are thousands of years old,
+    and that the world we experience in the present is only a fraction of
+    all that it ever was. Fundamental to historical analysis is the study
+    of change over time: why and how did cities rise and fall, technologies
+    develop, the social roles of men and women transform? Because we can
+    never directly experience the past, historical analysis depends on the
+    subjective selection and interpretation of texts, artifacts, and other
+    evidence, and from the same evidence many different stories can often
+    be told. Historical analysis requires students to make critical
+    judgments about the conclusions we can draw from the traces of the
+    past to which we have access.
+  dist_req: HA
+- name: Literature and the Arts
+  max_counted: 1
+  min_needed: 2
+  explanation: |-
+    <i>Two courses</i>
+
+    In courses in Literature and the Arts (LA), students may produce
+    creative, imaginative works or practice interpreting them. For example,
+    they may choreograph dances or read Shakespeare plays or create
+    performance pieces that use imaginative and interpretive skills
+    critically and physically. The skill of “close reading” is especially
+    important in this area of inquiry: what can we learn from careful
+    attention to the precise words, colors, or tones that an artist has chosen?
+
+    Human beings have always used imagination to create reflections and
+    representations of ourselves and our world, from cave paintings to
+    symphonies to video games. In making these artistic or imaginative
+    representations, we express ideas about our own nature and investigate
+    the nature of the world around us, often in ways that push at the
+    boundaries of what can be said in ordinary language.
+  dist_req: LA
+- name: Social Analysis
+  max_counted: 1
+  min_needed: 2
+  explanation: |-
+    <i>Two courses</i>
+
+    Social Analysis (SA) involves the study of the structures, processes,
+    and meanings human beings create through our interactions with one
+    another, and the networks and institutions through which human
+    behavior develops and evolves. The codes and narratives we share
+    with others, often unspoken, produce our sense of “the normal” and
+    structure our thought and behavior. These components of social life
+    are accessible through both quantitative methods, which involve the
+    statistical analysis of data, and qualitative methods, which rely on
+    the interpretation of data gathered through observation and interaction.
+    Social analysis enables us to make sense of the social structures and
+    processes that shape individual lives, to understand the role of
+    institutions—such as the family, government, schools, and labor
+    markets—in society, and to define and respond to social problems,
+    such as inequality and violence.
+  dist_req: SA
+- name: Quantitative and Computational Reasoning
+  max_counted: 1
+  min_needed: 1
+  explanation: |-
+    <i>One course</i>
+
+    Quantitative and Computational Reasoning (QCR) engages students in the
+    logic of mathematics and the manipulation of numerical and categorical
+    information. Quantitative reasoning asks us to describe and predict
+    things that can be measured or counted such as population, speed, or
+    cost. Computational thinking informs the underlying structures of the
+    codes and algorithms created in computer science. Quantitative and
+    computational reasoning is used to some degree in almost every area
+    of learning. A strong foundation in quantitative reasoning helps students
+    think clearly and apply quantitative methods to a wide range of projects,
+    and equips them to critically evaluate statistical claims.
+  dist_req:
+  - QR
+  - QCR
+- name: Science and Engineering
+  max_counted: 1
+  min_needed: 2
+  explanation: |-
+    <i>Two courses. At least one course must be a science and engineering
+    course with laboratory (SEL).</i>
+
+    Science and Engineering (SEL/SEN) encompass the study of the natural
+    and constructed worlds, their impact on humanity, and the human impact
+    on them. These disciplines teach principles, methods, and systematic
+    thinking, how to innovate theories and methodologies, how to test
+    ypotheses and prototypes by analyzing data while managing uncertainty,
+    and how to enhance the built world through creativity and design.
+    Fundamental to science and engineering are the methods and habits of
+    mind in which models are developed, critiqued, and refined, thereby
+    enriching and expanding our ways of understanding – and fascination
+    with – the natural and constructed environments, and our own positions
+    within them.
+
+    At least one course must be a science and engineering course with
+    laboratory (SEL). Students may elect a second laboratory science course,
+    or a nonlaboratory science course (SEN).
+  req_list:
+  - name: Science and Engineering with Lab
+    max_counted:
+    min_needed: 1
+    explanation: Science and Engineering with Lab (SEL)
+    dist_req:
+    - STL
+    - SEL
+  - name: Science and Engineering without Lab
+    max_counted: 1
+    min_needed:
+    explanation: Science and Engineering without Lab (SEN)
+    dist_req:
+    - STN
+    - SEN

--- a/majors_and_certificates/scripts/verifier.py
+++ b/majors_and_certificates/scripts/verifier.py
@@ -42,7 +42,7 @@ def check_major(major_name, courses, year):
     if (major_name not in university_info.AB_CONCENTRATIONS
             and major_name not in university_info.BSE_CONCENTRATIONS):
         raise ValueError("Major code not recognized.")
-    major_filename = "%s.json" % major_name
+    major_filename = "%s.yaml" % major_name
     major_filepath = os.path.join(_get_dir_path(), MAJORS_LOCATION, major_filename)
     return check_requirements(major_filepath, courses, year)
 
@@ -68,7 +68,7 @@ def check_degree(degree_name, courses, year):
         raise ValueError("Year is invalid.")
     if degree_name not in ["AB", "BSE"]:
         raise ValueError("Invalid degree name: %s" % degree_name)
-    degree_filename = "%s.json" % degree_name
+    degree_filename = "%s.yaml" % degree_name
     degree_filepath = os.path.join(_get_dir_path(), DEGREES_LOCATION, degree_filename)
     return check_requirements(degree_filepath, courses, year)
 
@@ -96,7 +96,7 @@ def check_certificate(certificate_name, courses, year):
         raise ValueError("Year is invalid.")
     if (certificate_name not in university_info.CERTIFICATES):
         raise ValueError("Certificate not recognized.")
-    certificate_filename = "%s.json" % certificate_name
+    certificate_filename = "%s.yaml" % certificate_name
     certificate_filepath = os.path.join(_get_dir_path(), CERTIFICATES_LOCATION, certificate_filename)
     return check_requirements(certificate_filepath, courses, year)
 
@@ -154,7 +154,7 @@ def get_courses_by_path(path):
         raise ValueError("Path malformatted.")
     if "/" in req_type or "/" in req_name:
         raise ValueError("Path malformatted.")
-    filename = "%s.json" % req_name
+    filename = "%s.yaml" % req_name
     if req_type == "Major":
         if (req_name not in university_info.AB_CONCENTRATIONS and req_name not in university_info.BSE_CONCENTRATIONS):
             raise ValueError("Path malformatted.")


### PR DESCRIPTION
* Convert the major, degree, and certificate requirement files from the `JSON` subset of [`YAML`](https://en.wikipedia.org/wiki/YAML) to the more succinct human-readable format (see [here](https://www.json2yaml.com/no-ads-or-analytics) for an example of the difference between them).
This pull request makes no actual changes to the requirements themselves. It merely rewrites them in a much more human-friendly way. Most of the rewrite is performed automatically by conversion software.

* Add more clarification to the [readme](https://github.com/PrincetonResInDe/course-selection/blob/f627cda89e0fa7ce304ac7b44e2a91664a718bbf/majors_and_certificates/README.md) for the majors and certificates requirements, as well as additional documentation where needed.