### PR TITLE
Fix MobileApp timeout issue in course/evals update script for older terms

### DIFF
--- a/back_end/database/evaluations.py
+++ b/back_end/database/evaluations.py
@@ -9,10 +9,14 @@ load_dotenv()
 """
     This class handles scraping for course evaluations.
 
-    INSTRUCTIONS: Before creating an EvalsScraper object, 
-    make sure you are logged into CAS on one of the browsers supported by browser_cookie3
-    (https://github.com/borisbabic/browser_cookie3). Or, you can 
-    manually add a valid "PHPSESSID" token in your .env file.
+    If running the code in EvalsScraper LOCALLY, log into CAS on one of the browsers 
+    supported by browser_cookie3 (https://github.com/borisbabic/browser_cookie3).
+    Or, you can manually add a valid "PHPSESSID" token in your .env file.
+
+    If running the code in EvalsScraper ON HEROKU, log into CAS, then retrieve the
+    value of the "PHPSESSID" cookie from your browser's Developer Console. 
+    Add "PHPSESSID" (key) and the retrieved token (value) as a Heroku Config Var in 
+    the Heroku app. 
 """
 
 

--- a/back_end/database/evaluations.py
+++ b/back_end/database/evaluations.py
@@ -24,13 +24,16 @@ class EvalsScraper:
         headers = {"user-agent": self.USER_AGENT}
 
         # Set up the cookies for getting past CAS
+        print("creating browser cookie obj...")
         cj = browser_cookie3.load(domain_name="registrarapps.princeton.edu")
+        print("extracting cookies...")
         cookies = requests.utils.dict_from_cookiejar(cj)
         if "PHPSESSID" in cookies:
             cookies = {"PHPSESSID": cookies["PHPSESSID"]}
         else:
             cookies = {"PHPSESSID": os.getenv("PHPSESSID")}
 
+        print("creating session...")
         session = requests.Session()
         session.cookies.update(cookies)
         session.headers.update(headers)

--- a/back_end/database/evaluations.py
+++ b/back_end/database/evaluations.py
@@ -24,16 +24,13 @@ class EvalsScraper:
         headers = {"user-agent": self.USER_AGENT}
 
         # Set up the cookies for getting past CAS
-        print("creating browser cookie obj...")
-        cj = browser_cookie3.load(domain_name="registrarapps.princeton.edu")
-        print("extracting cookies...")
-        cookies = requests.utils.dict_from_cookiejar(cj)
-        if "PHPSESSID" in cookies:
+        try:
+            cj = browser_cookie3.load(domain_name="registrarapps.princeton.edu")
+            cookies = requests.utils.dict_from_cookiejar(cj)
             cookies = {"PHPSESSID": cookies["PHPSESSID"]}
-        else:
+        except:
             cookies = {"PHPSESSID": os.getenv("PHPSESSID")}
 
-        print("creating session...")
         session = requests.Session()
         session.cookies.update(cookies)
         session.headers.update(headers)

--- a/back_end/database/mobileapp.py
+++ b/back_end/database/mobileapp.py
@@ -121,28 +121,29 @@ class MobileApp:
     # return course info for all courses in a given term
     # makes a batch query to MobileApp (all depts at once)
     # NOTE: should only use batch to get courses for current term;
-    # otherwise, MobileApp timeout error may occur, 
+    # otherwise, MobileApp timeout error may occur,
     def get_all_courses_BATCH(self, term: str) -> dict:
-        dept_codes =  ",".join(self.get_department_codes(term=term))
+        dept_codes = ",".join(self.get_department_codes(term=term))
         courses = []
         courses_raw = self.get_courses(term=term, subject=dept_codes, fmt="json")
         if len(courses_raw["term"]) > 0 and "subjects" in courses_raw["term"][0]:
-                courses = courses_raw["term"][0]["subjects"]
+            courses = courses_raw["term"][0]["subjects"]
         return courses
 
     # return course info for all courses in a given term
     # instead of making batch query to MobileApp, makes a Mobileapp
     # query for each dept to avoid MobileApp timeout issue
-    # NOTE: resulting dict may include duplicate course entries 
+    # NOTE: resulting dict may include duplicate course entries
     # for cross-listed courses
     def get_all_courses_INDIV(self, term: str) -> dict:
         dept_codes = self.get_department_codes(term=term)
-        courses = []        
+        courses = []
         for dept in dept_codes:
             courses_raw = self.get_courses(term=term, subject=dept, fmt="json")
             if len(courses_raw["term"]) > 0 and "subjects" in courses_raw["term"][0]:
                 courses.extend(courses_raw["term"][0]["subjects"])
         return courses
+
 
 if __name__ == "__main__":
     api = MobileApp()

--- a/back_end/database/update_db_courses.py
+++ b/back_end/database/update_db_courses.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 def update_courses_for_current_term() -> None:
     try:
         curr_term = MobileApp().get_current_term_code()
-        update_courses_for_one_term(curr_term)
+        update_courses_for_one_term(term=curr_term, batch=True)
     except Exception as e:
         logger.error(f"failed to update courses for current term with error {e}")
 

--- a/back_end/database/update_db_courses.py
+++ b/back_end/database/update_db_courses.py
@@ -55,7 +55,11 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     group = parser.add_mutually_exclusive_group()
-    group.add_argument("--terms", nargs="*", help="update courses for specified term(s) [please provide term code(s)]")
+    group.add_argument(
+        "--terms",
+        nargs="*",
+        help="update courses for specified term(s) [please provide term code(s)]",
+    )
     group.add_argument(
         "--curr", help="update courses for current term", action="store_true"
     )

--- a/back_end/database/update_db_courses.py
+++ b/back_end/database/update_db_courses.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
     $ python update_db_courses.py --curr
 
     To update courses for specified term(s):
-    $ python update_db_courses.py <term_code_1> <term_code_2> ...
+    $ python update_db_courses.py --terms <term_code_1> <term_code_2> ...
 
     To update courses for all terms:
     $ python update_db_courses.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     group = parser.add_mutually_exclusive_group()
-    group.add_argument("--terms", nargs="*", help="update courses for specified terms")
+    group.add_argument("--terms", nargs="*", help="update courses for specified term(s) [please provide term code(s)]")
     group.add_argument(
         "--curr", help="update courses for current term", action="store_true"
     )
@@ -63,8 +63,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.terms is None and args.curr is False:
-        # DO NOT RUN: CURRENTLY CRASHES MID-WAY DUE TO MOBILEAPP TIMEOUT ERROR
-        # TO-DO: work witb OIT about timeout issue
         print("Running script to update courses in DB for all terms...")
         update_courses_for_terms()
     elif args.curr:

--- a/back_end/database/update_db_evals.py
+++ b/back_end/database/update_db_evals.py
@@ -107,8 +107,11 @@ def update_evals_for_terms(terms: List[str] = None):
     try:
         db = DatabaseUtils()
         if terms is None:
+            print('getting terms...')
             terms = db.get_all_terms()
+            print('got terms...')
 
+        print('starting to update here...')
         # use multiprocessing to update terms in parallel
         with Pool(os.cpu_count()) as pool:
             pool.map(update_evals_for_one_term, terms)

--- a/back_end/database/update_db_evals.py
+++ b/back_end/database/update_db_evals.py
@@ -18,10 +18,16 @@ logger = logging.getLogger(__name__)
 """
     This script scrapes course evaluations and update evals stored in the database.
 
-    INSTRUCTIONS: Before running the evals update script, 
-    make sure you are logged into CAS on one of the browsers supported by browser_cookie3
-    (https://github.com/borisbabic/browser_cookie3). Or, you can 
-    manually add a valid "PHPSESSID" token in your .env file.
+    INSTRUCTIONS: 
+
+    If running the evals update script LOCALLY, log into CAS on one of the browsers 
+    supported by browser_cookie3 (https://github.com/borisbabic/browser_cookie3).
+    Or, you can manually add a valid "PHPSESSID" token in your .env file.
+
+    If running the evals update script ON HEROKU, log into CAS, then retrieve the
+    value of the "PHPSESSID" cookie from your browser's Developer Console. 
+    Add "PHPSESSID" (key) and the retrieved token (value) as a Heroku Config Var in 
+    the Heroku app. 
 
     To update courses for specified term(s):
     $ python update_db_evals.py --terms <term_code_1> <term_code_2> ...
@@ -59,7 +65,7 @@ def update_evals_for_one_term(term: str, batch: bool = False) -> None:
 
     id_tracker = set()  # track seen course ids
     up_counter = 0  # count num courses updated
-    total_counter = 0 # count total courses processed
+    total_counter = 0  # count total courses processed
 
     logger.info(f"started updating evals data for term {term}")
     for subject in all_courses:
@@ -105,7 +111,9 @@ def update_evals_for_one_term(term: str, batch: bool = False) -> None:
             except Exception as e:
                 logger.error(f"failed to update evals for course {guid} with error {e}")
 
-    logger.info(f"updated evals for {up_counter}/{total_counter} courses in term {term}")
+    logger.info(
+        f"updated evals for {up_counter}/{total_counter} courses in term {term}"
+    )
 
 
 # Update evaluations data in db for specified terms
@@ -126,7 +134,11 @@ def update_evals_for_terms(terms: List[str] = None):
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--terms", nargs="*", help="update evals for specified term(s) [please provide term code(s)]")
+    parser.add_argument(
+        "--terms",
+        nargs="*",
+        help="update evals for specified term(s) [please provide term code(s)]",
+    )
 
     args = parser.parse_args()
 

--- a/back_end/database/update_db_helpers.py
+++ b/back_end/database/update_db_helpers.py
@@ -17,7 +17,8 @@ This file contains helper methods used in update_db_*.py scripts to update term 
 
 # Update course information for one term
 # term: term code
-def update_courses_for_one_term(term: str) -> None:
+# batch: set to True to make batch query to MobileApp 
+def update_courses_for_one_term(term: str, batch: bool = False) -> None:
     db = DatabaseUtils()
 
     if not db.is_valid_term_code(code=term):
@@ -26,8 +27,11 @@ def update_courses_for_one_term(term: str) -> None:
 
     # get course data from mobileapp api
     try:
-        logger.info(f"getting course data for term {term} from mobileapp")
-        all_courses = MobileApp().get_all_courses(term)
+        logger.info(f"getting course data for term {term} from mobileapp ({'non-batch' if not batch else 'batch'} query)")
+        if batch:
+            all_courses = MobileApp().get_all_courses_BATCH(term)
+        else:
+            all_courses = MobileApp().get_all_courses_INDIV(term)
     except Exception as e:
         logger.error(
             f"unable to get course data for term {term} from mobileapp with error {e}"
@@ -36,18 +40,28 @@ def update_courses_for_one_term(term: str) -> None:
 
     # NOTE: it may be possible that courses can be deleted, instructors
     # removed from a course. only do two clearing operations below
-    # if confident that update for all courses will not fail.
+    # for current term and if confident that update for all courses 
+    # will not fail.
     # db.clear_courses_for_one_term(term)
     # db.clear_courses_for_instructor_for_one_term(term)
+    
+    id_tracker = set() # track seen course ids
+    counter = 0 # count num courses updated
 
     logger.info(f"started updating courses for term {term}")
     for subject in all_courses:
         dept = subject["code"]
 
-        logger.info(f"processing courses for {dept}")
+        logger.info(f"processing {'all' if batch else 'some'} courses for {dept}")
         for mapp_course in subject["courses"]:
             guid = mapp_course["guid"]
             course_id = mapp_course["course_id"]
+
+            # skip duped courses (only applies for non-batch course queries)
+            if not batch:
+                if course_id in id_tracker:
+                    continue
+                id_tracker.add(course_id)
 
             # get course data from registrar's api
             try:
@@ -81,10 +95,13 @@ def update_courses_for_one_term(term: str) -> None:
 
                 # update courses collection with course data
                 db.update_course_data(guid, data)
+                counter += 1
             except Exception as e:
                 logger.error(
                     f"failed to parse & update course data for course {guid} with error {e}"
                 )
+    
+    logger.info(f"updated {counter} courses for term {term}")
 
 
 # Combines MobileApp and Registrar's API data into one dictionary
@@ -109,7 +126,6 @@ def parse_mobileapp_course_data(course: json) -> dict:
     data["crosslistings"] = course.get("crosslistings", [])
     data["classes"] = course.get("classes", [])
 
-    # change to use get()
     if "detail" in course:
         details = course["detail"]
         data["description"] = details.get("description", None)

--- a/back_end/database/update_db_helpers.py
+++ b/back_end/database/update_db_helpers.py
@@ -177,7 +177,7 @@ def parse_registrar_course_data(course: json) -> dict:
             "audit": False,
         },
         "NPD": {"pdf": {"required": False, "permitted": False}, "audit": True},  # npdf
-        "NPD": {  # P/D/F only
+        "PDF": {  # P/D/F only
             "pdf": {"required": True, "permitted": True},
             "audit": True,
         },

--- a/back_end/database/update_db_helpers.py
+++ b/back_end/database/update_db_helpers.py
@@ -17,7 +17,7 @@ This file contains helper methods used in update_db_*.py scripts to update term 
 
 # Update course information for one term
 # term: term code
-# batch: set to True to make batch query to MobileApp 
+# batch: set to True to make batch query to MobileApp
 def update_courses_for_one_term(term: str, batch: bool = False) -> None:
     db = DatabaseUtils()
 
@@ -27,7 +27,9 @@ def update_courses_for_one_term(term: str, batch: bool = False) -> None:
 
     # get course data from mobileapp api
     try:
-        logger.info(f"getting course data for term {term} from mobileapp ({'non-batch' if not batch else 'batch'} query)")
+        logger.info(
+            f"getting course data for term {term} from mobileapp ({'non-batch' if not batch else 'batch'} query)"
+        )
         if batch:
             all_courses = MobileApp().get_all_courses_BATCH(term)
         else:
@@ -40,13 +42,13 @@ def update_courses_for_one_term(term: str, batch: bool = False) -> None:
 
     # NOTE: it may be possible that courses can be deleted, instructors
     # removed from a course. only do two clearing operations below
-    # for current term and if confident that update for all courses 
+    # for current term and if confident that update for all courses
     # will not fail.
     db.clear_courses_for_one_term(term)
     db.clear_courses_for_instructor_for_one_term(term)
-    
-    id_tracker = set() # track seen course ids
-    counter = 0 # count num courses updated
+
+    id_tracker = set()  # track seen course ids
+    counter = 0  # count num courses updated
 
     logger.info(f"started updating courses for term {term}")
     for subject in all_courses:
@@ -100,7 +102,7 @@ def update_courses_for_one_term(term: str, batch: bool = False) -> None:
                 logger.error(
                     f"failed to parse & update course data for course {guid} with error {e}"
                 )
-    
+
     logger.info(f"updated {counter} courses for term {term}")
 
 

--- a/back_end/database/update_db_helpers.py
+++ b/back_end/database/update_db_helpers.py
@@ -49,7 +49,7 @@ def update_courses_for_one_term(term: str, batch: bool = False) -> None:
 
     id_tracker = set()  # track seen course ids
     up_counter = 0  # count num courses updated
-    total_counter = 0 # count total courses processed
+    total_counter = 0  # count total courses processed
 
     logger.info(f"started updating courses for term {term}")
     for subject in all_courses:

--- a/back_end/database/update_db_helpers.py
+++ b/back_end/database/update_db_helpers.py
@@ -42,8 +42,8 @@ def update_courses_for_one_term(term: str, batch: bool = False) -> None:
     # removed from a course. only do two clearing operations below
     # for current term and if confident that update for all courses 
     # will not fail.
-    # db.clear_courses_for_one_term(term)
-    # db.clear_courses_for_instructor_for_one_term(term)
+    db.clear_courses_for_one_term(term)
+    db.clear_courses_for_instructor_for_one_term(term)
     
     id_tracker = set() # track seen course ids
     counter = 0 # count num courses updated

--- a/back_end/database/update_db_helpers.py
+++ b/back_end/database/update_db_helpers.py
@@ -44,11 +44,12 @@ def update_courses_for_one_term(term: str, batch: bool = False) -> None:
     # removed from a course. only do two clearing operations below
     # for current term and if confident that update for all courses
     # will not fail.
-    db.clear_courses_for_one_term(term)
-    db.clear_courses_for_instructor_for_one_term(term)
+    # db.clear_courses_for_one_term(term)
+    # db.clear_courses_for_instructor_for_one_term(term)
 
     id_tracker = set()  # track seen course ids
-    counter = 0  # count num courses updated
+    up_counter = 0  # count num courses updated
+    total_counter = 0 # count total courses processed
 
     logger.info(f"started updating courses for term {term}")
     for subject in all_courses:
@@ -64,6 +65,8 @@ def update_courses_for_one_term(term: str, batch: bool = False) -> None:
                 if course_id in id_tracker:
                     continue
                 id_tracker.add(course_id)
+
+            total_counter += 1
 
             # get course data from registrar's api
             try:
@@ -97,13 +100,13 @@ def update_courses_for_one_term(term: str, batch: bool = False) -> None:
 
                 # update courses collection with course data
                 db.update_course_data(guid, data)
-                counter += 1
+                up_counter += 1
             except Exception as e:
                 logger.error(
                     f"failed to parse & update course data for course {guid} with error {e}"
                 )
 
-    logger.info(f"updated {counter} courses for term {term}")
+    logger.info(f"updated data for {up_counter}/{total_counter} courses in term {term}")
 
 
 # Combines MobileApp and Registrar's API data into one dictionary
@@ -230,4 +233,4 @@ def parse_registrar_course_data(course: json) -> dict:
 
 
 if __name__ == "__main__":
-    update_courses_for_one_term(term="1224")
+    update_courses_for_one_term(term="1224", batch=True)


### PR DESCRIPTION
# Goals
* Previously, our course/evals updater scripts were crashing with a timeout error when making requests to MobileApp API for course data, especially for previous terms. 
* According to OIT, the timeout error was happening because we were attempting to make batch queries to the API, i.e. we were trying to get all course data for a term with one query, by putting all department codes in one string for the "subject". Instead, OIT suggests for each term, we make one query for each department to avoid the timeout issue.

# Major Changes
* In this PR, I modified the course/evals update script as such: 
    - When we're updating course data for ALL terms or evals data for any terms, we make individual queries for each department, no batch queries are made to MobileApp. 
    - When we're updating course data for the CURRENT term, we make a batch query to MobileApp. So far, batch query for the current term has never failed (and is also used by TigerSnatch). 
    - Note that making one batch query is significantly faster than making individual queries. However, since we're only planning to run the course updater script once for all terms + evals updater script once per semester, optimizing for performance is unnecessary. However, since we plan to update course data for the current term very often throughout course selection / add-drop and periodically throughout the semester, we want the MobileApp query to be faster (the timeout issue has never occurred for the current term).

# Minor Changes
* Loading cookies with `browser_cookie3` fails once the code is deployed to Heroku. I wrapped this logic in a try-except so that if we run the evals script on Heroku, the script will default to using the `PHPSESSID` token stored in the Heroku config vars. 
* Fixed typo in hard-coded `GRADING_BASIS_MAPPINGS` dict (used to parse Registrar's API response)
* Nits: Fixed some typos in script header comments, added more/better logs.

# Testing
* Ran two full runs of course updater script for ALL terms (non-batch queries) and verified no timeout errors
* Ran one full run of evals updater script for ALL terms (non-batch queries) and verified no timeout errors
* Ran course updater script for current term (batch query) and verified no timeout errors

# Future Work
* Set up cron job for course updater script
* Write up docs for running course / evals updater script (esp communicate that evals updater script must be manually run)