### PR TITLE
get-course-info endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # course-selection
+# Running the Program -- Frontend.
+To run the program, cd into the front_end directory.
+Run ```npm install``` to install the required packages.
+Use ```npm start``` to run the program. It will run on localhost:3000
+
+
+# Running the Program -- Backend.
+To run the program, ensure that your .env files are set up. See back_end README.md for instructions.
+
+Then, use ```flask run``` to run the program. It will run on localhost:5000

--- a/app.py
+++ b/app.py
@@ -64,6 +64,7 @@ def test_database():
     logger.info("Reached /api/test-database")
     return jsonify(db.get_all_test())
 
+
 @app.route("/search", methods=["GET"])
 def search():
     args = request.args
@@ -91,4 +92,14 @@ def search():
 
     # See database_api.py for structure of input query
     res = do_search(query_dict)
+    return jsonify(res)
+
+
+@app.route("/api/get-course-info", methods=["GET"])
+def course_info():
+    logger.info("Reached /api/course-info")
+    args = request.args
+    course_id = args.get("course_id", "")
+    semester = args.get("semester", "")
+    res = db.get_course_info(course_id, semester)
     return jsonify(res)

--- a/database_api.py
+++ b/database_api.py
@@ -96,6 +96,9 @@ class DatabaseAPI:
                 f"Error displayed below:\n{e}"
             )
             ret = None
+        # Note, right now this returns a ton of information
+        # If this information is difficult to use on the front end
+        # This code can be modified going forward to meet this need
         return ret
 
     def close(self):


### PR DESCRIPTION
In this PR, the get-course-info endpoint was created for the backend. 

This endpoint returns 2 things (all packaged into one return) 
1: All the information associated with a course_id and the semester
2: All of the course reviews associated with the course_id (across many semesters)
```

        params: query = {
                             "course_id": "the course_id",
                             "semester = "semester_in_words"
                        }

       Semester is of format Spring/Summer/Fall Year

       Example from COS 126, Fall 2021:
            query = { "course_id": "002051", "semester": "Fall 2021" }
```

Use command `flask run` to start the server.
I would suggest using Postman to make these queries, as that can make the testing process go straightforward.
This is a sample string if you'd rather test in your browser:
`http://localhost:5000/api/get-course-info?course_id=002051&semester=Fall 2021`